### PR TITLE
修复生成模板当 Model.Operations.Parameters.Schema 为空时的异常

### DIFF
--- a/WebApiClient.Tools.Swagger/Views/HttpApi.cshtml
+++ b/WebApiClient.Tools.Swagger/Views/HttpApi.cshtml
@@ -100,12 +100,10 @@
                             if (parameter.Kind == SwaggerParameterKind.Path || parameter.Kind == SwaggerParameterKind.Query)
                             {
                                 var schema = parameter.Schema as NSwag.SwaggerParameter;
-                                if (schema != null && schema.CollectionFormat != SwaggerParameterCollectionFormat.Undefined)
+                                if (schema != null && schema.CollectionFormat != SwaggerParameterCollectionFormat.Undefined 
+                                    && schema.CollectionFormat != SwaggerParameterCollectionFormat.Multi)
                                 {
-                                    if (schema.CollectionFormat != SwaggerParameterCollectionFormat.Multi)
-                                    {
-                                        <span>[PathQuery(CollectionFormat = CollectionFormat.@(schema.CollectionFormat))]</span>
-                                    }
+                                    <span>[PathQuery(CollectionFormat = CollectionFormat.@(schema.CollectionFormat))]</span>
                                 }
                             }
                             else if (parameter.Kind == SwaggerParameterKind.Header)


### PR DESCRIPTION
修复生成模板当 Model.Operations.Parameters.Schema 为空时的异常
bug描述：
我在本地新创建了一个 ASP.Net core 2.2 WebAPI项目，并加入了 Nswag，新项目中未做任何改动。
拿到 swagger.json 后，使用本工具测试自动生成代码时抛出对象为空的异常，通过查看源码，找到了该报错代码缺少对象为空的判断。
bug修复：
在 HttpApi.cshtml 模板中加上了对 Model.Operations.Parameters.Schema 使用之前的对象是否为空的判断。